### PR TITLE
added option to allow for check hook output in email body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Added option to allow for including check hook output in the email body
+
 ## [0.0.2] - 2018-12-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Flags:
   -p, --smtpPassword string   The SMTP password
   -P, --smtpPort uint16       The SMTP server port (default 587)
   -u, --smtpUsername string   The SMTP username
+  -H, --hookout               Include output from check hook(s)
 ```
 
 ## Contributing

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	toEmail      string
 	fromEmail    string
 	subject      string
+	hookout      bool
 	stdin        *os.File
 
 	emailSubjectTemplate = "Sensu Alert - {{.Entity.Name}}/{{.Check.Name}}: {{.Check.State}}"
@@ -41,6 +42,7 @@ func main() {
 	cmd.Flags().Uint16VarP(&smtpPort, "smtpPort", "P", 587, "The SMTP server port")
 	cmd.Flags().StringVarP(&toEmail, "toEmail", "t", "", "The 'to' email address")
 	cmd.Flags().StringVarP(&fromEmail, "fromEmail", "f", "", "The 'from' email address")
+	cmd.Flags().BoolVarP(&hookout, "hookout", "H", false, "Include output from check hook(s)")
 
 	cmd.Execute()
 }
@@ -97,6 +99,9 @@ func checkArgs() error {
 	}
 	if len(smtpPassword) == 0 {
 		return errors.New("smtp password is empty")
+	}
+	if hookout {
+		emailBodyTemplate = "{{.Check.Output}}\n{{range .Check.Hooks}}Hook Name:  {{.Name}}\nHook Command:  {{.Command}}\n\n{{.Output}}\n\n{{end}}"
 	}
 	if len(fromEmail) == 0 {
 		return errors.New("from email is empty")


### PR DESCRIPTION
The feature I implemented for #4 

Signed-off-by: Todd Campbell <todd@toddcampbell.net>

Closes #4 