### PR TITLE
Add tlsSkipVerify and authMethod flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- Deprecated the `insecure` flag. Use the combination of `--tlsSkipVerify`,
+  `--authMethod none`, and `--smtpPort 25` for the same behavior.
+- Deprecated the `enableLoginAuth` flag in favor of `--authMethod login`.
+
+### Added
+- Added `tlsSkipVerify` option to disable TLS certificate checks
+- Added `authMethod` flag to switch between none, plain, and login auth
+
 ## [0.2.0] - 2019-07-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -50,18 +50,20 @@ Usage:
   sensu-email-handler [flags]
 
 Flags:
+  -a, --authMethod string         The SMTP authentication method, one of 'none', 'plain', or 'login' (default "plain")
   -T, --bodyTemplateFile string   A template file to use for the body
-  -t, --toEmail string            The 'to' email address
+  -l, --enableLoginAuth           [deprecated] Use "login auth" mechanisim
   -f, --fromEmail string          The 'from' email address
   -h, --help                      help for sensu-email-handler
+  -H, --hookout                   Include output from check hook(s)
+  -i, --insecure                  [deprecated] Use an insecure connection (unauthenticated on port 25)
   -s, --smtpHost string           The SMTP host to use to send to send email
   -p, --smtpPassword string       The SMTP password, if not in env SMTP_PASSWORD
-  -P, --smtpPort uint16           The SMTP server port (default 587)
+  -P, --smtpPort uint             The SMTP server port (default 587)
   -u, --smtpUsername string       The SMTP username, if not in env SMTP_USERNAME
-  -H, --hookout                   Include output from check hook(s)
-  -i, --insecure                  Use an insecure connection (unauthenticated on port 25)
-  -l, --enableLoginAuth           Use "login auth" mechanism
   -S, --subjectTemplate string    A template to use for the subject (default "Sensu Alert - {{.Entity.Name}}/{{.Check.Name}}: {{.Check.State}}")
+  -k, --tlsSkipVerify             Do not verify TLS certificates
+  -t, --toEmail string            The 'to' email address
 ```
 
 ### Annotations


### PR DESCRIPTION
These replace the existing `insecure` and `enableLoginAuth` flags, which are now deprecated (but still functional.) By combining the two new flags with the existing `smtpPort` flag, users can replicate the behavior of the `insecure` flag, but now have more options for supporting a wider range of SMTP servers.

Because of the interaction between these options, no longer use the `smtp.SendMail` helper function, but implement the SMTP exchange using the lower-level client methods.

Fixes #24.