### PR TITLE
Remove replacing newlines with HTML line breaks in HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,23 +138,23 @@ The plugin provides an option to use a template as for the body of the email and
 Greetings,
 
 <h3>Informational Details</h3>
-<b>Check</b>: {{ .Check.Name }}
-<b>Entity</b>: {{ .Entity.Name }}
-<b>State</b>: {{ .Check.State }}
-<b>Occurrences</b>: {{ .Check.Occurrences }}
+<b>Check</b>: {{ .Check.Name }}<br>
+<b>Entity</b>: {{ .Entity.Name }}<br>
+<b>State</b>: {{ .Check.State }}<br>
+<b>Occurrences</b>: {{ .Check.Occurrences }}<br>
 <b>Playbook</b>: https://example.com/monitoring/wiki/playbook
 <h3>Check Output Details</h3>
 <b>Check Output</b>: {{.Check.Output}}
 <h4>Check Hook(s)</h4>
-{{range .Check.Hooks}}<b>Hook Name</b>:  {{.Name}}
-<b>Hook Command</b>:  {{.Command}}
-<b>Hook Output</b>: {{.Output}}
-{{end}}
-
-
+{{range .Check.Hooks}}<b>Hook Name</b>:  {{.Name}}<br>
+<b>Hook Command</b>:  {{.Command}}<br>
+<b>Hook Output</b>: {{.Output}}<br>
+{{end}}<br>
+<br>
+<br>
 #monitoringlove,<br>
-
-Sensu
+<br>
+Sensu<br>
 </html>
 ```
 

--- a/main.go
+++ b/main.go
@@ -378,12 +378,6 @@ func resolveTemplate(templateValue string, event *corev2.Event, contentType stri
 		return "", err
 	}
 
-	// \n replacement must be done after tmpl.Execute to catch
-	// template values
-	if contentType == ContentHTML {
-		return strings.Replace(resolved.String(), "\n", "<br>", -1), nil
-	}
-
 	return resolved.String(), nil
 }
 


### PR DESCRIPTION
Closes #47 

However it reverts #36 and that issue will need to be re-visited or handled differently (manually inserting your own line breaks in the template).