### PR TITLE
Provide human readable timestamps in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Add template function to allow formatting of event timestamps
+
 ## [0.6.0] - 2020-05-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   - [Handler definition](#handler-definition)
 - [Annotations](#annotations)
 - [Templates](#templates)
+  - [Formatting Timestamps in Templates](#formatting-dates-in-templates)
 - [Installing from source and contributing](#installing-from-source-and-contributing)
 
 ## Overview
@@ -170,6 +171,28 @@ Hook Name:  {{.Name}}
 Hook Command:  {{.Command}}
 {{.Output}}
 ```
+#### Formatting Timestamps in Templates
+
+A Sensu Go event contains multiple timestamps (e.g. .Check.Issued,
+.Check.Executed, .Check.LastOk) that are presented in [UNIX timestamp][3]
+format.  A function named UnixTime is provided to print these values in a
+customizable human readable format as part of a template.  To customize the
+output format of the timestamp, use the same format as specified by Golang's
+[Time.Format][4].  Additional examples can be found [here][5].
+
+**Note:** the predefined format constants are **not** available.
+
+The example below embellishes the prior example template to include two
+timestamps.
+
+```
+[...]
+<h3>Check Output Details</h3>
+<b>Executed</b>: {{(UnixTime .Check.Executed).Format "2 Jan 2006 15:04:05"}}<br>
+<b>Last OK</b>: {{(UnixTime .Check.LastOK).Format "2 Jan 2006 15:04:05"}}<br>
+<b>Check Output</b>: {{.Check.Output}}
+[...]
+```
 
 ## Installing from source and contributing
 
@@ -185,3 +208,6 @@ For additional instructions, see [CONTRIBUTING](https://github.com/sensu/sensu-g
 
 [1]: https://github.com/sensu/sensu-email-handler/releases
 [2]: https://docs.sensu.io/sensu-go/latest/reference/handlers/#how-do-sensu-handlers-work
+[3]: https://en.wikipedia.org/wiki/Unix_time
+[4]: https://golang.org/pkg/time/#Time.Format
+[5]: https://yourbasic.org/golang/format-parse-string-time-date-example/

--- a/main.go
+++ b/main.go
@@ -363,10 +363,14 @@ func resolveTemplate(templateValue string, event *corev2.Event, contentType stri
 	)
 	if contentType == ContentHTML {
 		// parse using html/template
-		tmpl, err = htemplate.New("test").Parse(templateValue)
+		tmpl, err = htemplate.New("test").Funcs(htemplate.FuncMap{
+			"UnixTime": func(i int64) time.Time { return time.Unix(i, 0) },
+		}).Parse(templateValue)
 	} else {
 		// default parse using text/template
-		tmpl, err = ttemplate.New("test").Parse(templateValue)
+		tmpl, err = ttemplate.New("test").Funcs(ttemplate.FuncMap{
+			"UnixTime": func(i int64) time.Time { return time.Unix(i, 0) },
+		}).Parse(templateValue)
 	}
 
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/stretchr/testify/assert"
 )
 
 var tcRcpts = []struct {
@@ -54,4 +54,3 @@ func TestResolveTemplate(t *testing.T) {
 	expected = fmt.Sprintf("<html>Entity: foo Check: bar Executed: %s</html>", executedFormatted)
 	assert.Equal(t, templout, expected)
 }
-


### PR DESCRIPTION
This change adds the ability to extract customizable human readable timestamps from the event's UNIX based timestamps.