### PR TITLE
Use net.JoinHostPort instead of fmt.Sprintf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- Use net.JoinHostPort instead of fmt.Sprintf for Host:Port to make semgrep happy
+
 ## [1.0.0] - 2020-10-30
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -9,8 +9,10 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	"net"
 	"net/mail"
 	"net/smtp"
+	"strconv"
 	"strings"
 	ttemplate "text/template"
 	"time"
@@ -277,7 +279,7 @@ func checkArgs(_ *corev2.Event) error {
 func sendEmail(event *corev2.Event) error {
 	var contentType string
 
-	smtpAddress := fmt.Sprintf("%s:%d", config.SmtpHost, config.SmtpPort)
+	smtpAddress := net.JoinHostPort(config.SmtpHost, strconv.FormatUint(config.SmtpPort, 10))
 	subject, subjectErr := resolveTemplate(config.SubjectTemplate, event, ContentPlain)
 	if subjectErr != nil {
 		return subjectErr


### PR DESCRIPTION
Per semgrep, replace fmt.Sprintf of Host and Port with net.JoinHostPort

Signed-off-by: Todd Campbell <todd@sensu.io>